### PR TITLE
Adds testing under NodeJS 8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
+    - "8"
     - "6"
     - "4"
 sudo: false


### PR DESCRIPTION
NodeJS 8.x just entered [active LTS](https://github.com/nodejs/Release#release-schedule), so it should arguably be tested, too. 