### PR TITLE
Updates development dependencies and promotes to v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 dist: trusty
 node_js:
+    - "8"
     - "6"
     - "4"
 sudo: false
@@ -14,4 +15,4 @@ deploy:
   on:
     tags: true
     repo: hlapp/node-red-embedded-start
-    node: "4"
+    node: "6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-embedded-start",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "description": "Enables waiting for flows to have started for embedded Node-RED applications",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enables waiting for flows to have started for embedded Node-RED applications",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/01.js && tape test/02.js",
+    "test": "tape test/??.js",
     "lint": "eslint .",
     "pretest": "npm run lint"
   },
@@ -24,9 +24,9 @@
   },
   "homepage": "https://github.com/hlapp/node-red-embedded-start#readme",
   "devDependencies": {
-    "eslint": "^4.2.0",
-    "node-red": "^0.17.2",
-    "sinon": "^2.3.2",
-    "tape": "^4.6.3"
+    "eslint": "^4.17.0",
+    "node-red": "^0.18.0",
+    "sinon": "^4.0.0",
+    "tape": "^4.8.0"
   }
 }


### PR DESCRIPTION
In essence, this promotes the functionality from v0.1.2 to v1.0.0. The v0.1.2 release is now almost 12 months old, and there are no new features planned or bugs currently reported. Releases v0.1.3 and v0.1.4 were solely maintenance, and did not improve or change any functionality.