### PR TITLE
Fixes warnings in test 02 by running it separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Enables waiting for flows to have started for embedded Node-RED applications",
   "main": "index.js",
   "scripts": {
-    "test": "tape test/??.js",
+    "test": "tape test/01.js && tape test/02.js",
     "lint": "eslint .",
     "pretest": "npm run lint"
   },

--- a/test/02.js
+++ b/test/02.js
@@ -1,5 +1,13 @@
 "use strict";
 
+/*
+ * Note this test suite needs to be run as its independent process, i.e., as
+ * its own invocation with tape. Otherwise the RED embedded runtime will have
+ * been initialized already, and the tests here are then not only mostly
+ * pointless, but the calls to RED.init() and RED.start() will produce
+ * warning messages.
+ */
+
 var test = require('tape'),
     sinon = require('sinon');
 var embeddedStart = require('../'),


### PR DESCRIPTION
They used to be run separately, but this was accidentally changed in ba3ddd3dc06f9ec9d8d46d71160bc43a414a77b5. Also adds a comments to the top of test 02 to prevent a future accidental reversion.